### PR TITLE
Improved locale lookup via Accept-Language strategy

### DIFF
--- a/src/SlmLocale/Strategy/HttpAcceptLanguageStrategy.php
+++ b/src/SlmLocale/Strategy/HttpAcceptLanguageStrategy.php
@@ -67,8 +67,8 @@ class HttpAcceptLanguageStrategy extends AbstractStrategy
                     return $locale;
                 }
 
-                if (Locale::lookup($supported, $locale)) {
-                    return $locale;
+                if ($match = Locale::lookup($supported, $locale)) {
+                    return $match;
                 }
             }
         }

--- a/tests/SlmLocaleTest/Strategy/HttpAcceptLanguageStrategyTest.php
+++ b/tests/SlmLocaleTest/Strategy/HttpAcceptLanguageStrategyTest.php
@@ -121,4 +121,24 @@ class HttpAcceptLanguageStrategyTest extends TestCase
         $locale = $strategy->detect($event);
         $this->assertEquals('bar', $locale);
     }
+    
+    public function testSelectsLanguageViaLocaleLookup()
+    {
+        $strategy = $this->strategy;
+        $event    = $this->event;
+
+        $header   = new AcceptLanguage;
+        $header->addLanguage('de-DE', 1);
+        $header->addLanguage('en-US', 0.8);
+        $header->addLanguage('en', 0.6);
+
+        $event->getRequest()
+            ->getHeaders()
+            ->addHeader($header);
+
+        $event->setSupported(array('en', 'de'));
+
+        $locale = $strategy->detect($event);
+        $this->assertEquals('de', $locale);
+    }    
 }


### PR DESCRIPTION
This small tweak allows for easier support of multiple regions.

If I support the locales `['de', 'en', 'es', 'fr']`, and the browser is asking for `'en-US'`, it will still yield a match and correctly pick `'en'`.

Unit test case added to demo the behavior.