### PR TITLE
Locale detector only for GET method

### DIFF
--- a/src/SlmLocale/Locale/Detector.php
+++ b/src/SlmLocale/Locale/Detector.php
@@ -44,6 +44,7 @@ use SlmLocale\LocaleEvent;
 use SlmLocale\Strategy\StrategyInterface;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
+use Zend\Http\Request as HttpRequest;
 use Zend\Stdlib\RequestInterface;
 use Zend\Stdlib\ResponseInterface;
 use Zend\Uri\Uri;
@@ -121,7 +122,7 @@ class Detector implements EventManagerAwareInterface
 
     public function detect(RequestInterface $request, ResponseInterface $response = null)
     {
-        if (!$request->isGet()) {
+        if ($request instanceof HttpRequest && !$request->isGet()) {
             return;
         }
 

--- a/src/SlmLocale/Locale/Detector.php
+++ b/src/SlmLocale/Locale/Detector.php
@@ -121,6 +121,10 @@ class Detector implements EventManagerAwareInterface
 
     public function detect(RequestInterface $request, ResponseInterface $response = null)
     {
+        if (!$request->isGet()) {
+            return;
+        }
+
         $event = new LocaleEvent(LocaleEvent::EVENT_DETECT, $this);
         $event->setRequest($request);
         $event->setResponse($response);


### PR DESCRIPTION
If you use the ZF2 method router, it's impossible to allow only POST / PUT methods for a route, because SlmLocale will change the URI. Also all POSTs are redirected, which is not what I want.

This PR addresses this and allows only GET methods to be changed by SlmLocale.